### PR TITLE
Use cache_variables for CMake options in conanfile.py

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ env:
 # for matrix check https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners
 jobs:
   prepare_matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.matrix_setup.outputs.matrix }}
     steps:

--- a/conanfile.py
+++ b/conanfile.py
@@ -100,7 +100,7 @@ class ExamplePluginsConan(ConanFile):
         tc.variables["ManiVault_DIR"] = manivault_dir
 
         # Set some build options
-        tc.variables["MV_UNITY_BUILD"] = "ON"
+        tc.cache_variables["MV_UNITY_BUILD"] = "ON"
 
         # Use vcpkg-installed dependencies if there are any
         if os.environ.get("VCPKG_ROOT", None):


### PR DESCRIPTION
`tc.variables[...]` sets a normal CMake variable and `tc.cache_variable[...]` should be used for CMake options, see the [conan docs](https://docs.conan.io/2/reference/tools/cmake/cmaketoolchain.html).

Drive-by:
- Use `ubuntu-slim` instead of `ubuntu-latest`. This uses a container rather than a whole VM and might lead to a little faster setup