### PR TITLE
Use `actions/cache` instead of nuget to cache vcpkg dependencies on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,14 +35,14 @@ jobs:
 
       - name: Checkout the source
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Checkout the source - pull request
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -54,12 +54,12 @@ jobs:
           sudo xcode-select -switch /Applications/Xcode_${{matrix.build-xcode-version}}.app
 
       - name: Setup python version
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Start ssh key agent
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.RULESSUPPORT_DEPLOY_KEY }}
 
@@ -85,7 +85,7 @@ jobs:
           echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $env:GITHUB_ENV
 
       - name: Set up binary cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}/vcpkg-cache
           key: vcpkg-cache-${{ runner.os }}-${{ matrix.os }}-${{ matrix.build-cversion }}-${{ env.VCPKG_COMMIT_SHA }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
-  USERNAME: ManiVaultStudio
-  FEED_URL: https://nuget.pkg.github.com/ManiVaultStudio/index.json
-  VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/ManiVaultStudio/index.json,readwrite"
+  VCPKG_COMMIT_SHA: 56bb2411609227288b70117ead2c47585ba07713 # corresponds to tag 2026.04.27
 
 # for matrix check https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners
 jobs:
@@ -73,95 +69,42 @@ jobs:
           key: ${{ secrets.RULESSUPPORT_DEPLOY_KEY }}
           known_hosts: github.com AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
 
-      # Install vcpkg
-      - name: Clone vcpkg
+      - name: Set vcpkg environment (Unix)
+        if: "!startsWith(runner.os, 'Windows')"
         run: |
-          cd ${{ github.workspace }}
-          git clone --branch 2025.02.14 --single-branch https://github.com/microsoft/vcpkg.git
+          echo "VCPKG_DIR=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_ROOT=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $GITHUB_ENV
 
-      # Bootstrap vcpkg
-      - name: Bootstrap vcpkg 
-        if: startsWith(matrix.os, 'windows')
-        shell: pwsh
-        run:  |
-          ${{ github.workspace }}\vcpkg\bootstrap-vcpkg.bat
-          echo "VCPKG_ROOT=${{ github.workspace }}\vcpkg" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "VCPKG_EXE=${{ github.workspace }}\vcpkg\vcpkg.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "VCPKG_LIBRARY_LINKAGE=dynamic" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Bootstrap vcpkg
-        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
-        shell: bash
-        run: |
-          ${{ github.workspace }}/vcpkg/bootstrap-vcpkg.sh 
-          echo "VCPKG_ROOT=${{ github.workspace }}/vcpkg" >> $GITHUB_ENV
-          echo "VCPKG_EXE=${{ github.workspace }}/vcpkg/vcpkg" >> $GITHUB_ENV
-          echo "VCPKG_LIBRARY_LINKAGE=dynamic" >> $GITHUB_ENV
-
-      - name: NuGet dependencies (Linux)
-        if: startsWith(matrix.os, 'ubuntu')
-        shell: bash
-        run:  |
-          sudo apt update && sudo apt install -y mono-complete
-
-      - name: NuGet dependencies (MacOS)
-        if: startsWith(matrix.os, 'macos') && !endsWith(matrix.os, '13')
-        shell: bash
-        run:  |
-          brew install mono
-
-      # Use cached vcpkg packages if possible
-      - name: Add NuGet sources
-        if: startsWith(matrix.os, 'windows')
+      - name: Set vcpkg environmentg (Windows)
+        if: startsWith(runner.os, 'Windows')
         shell: pwsh
         run: |
-          .$(${{ env.VCPKG_EXE }} fetch nuget) `
-            sources add `
-            -Source "${{ env.FEED_URL }}" `
-            -StorePasswordInClearText `
-            -Name GitHubPackages `
-            -UserName "${{ env.USERNAME }}" `
-            -Password "${{ secrets.GH_VCPKG_PACKAGES }}"
-          .$(${{ env.VCPKG_EXE }} fetch nuget) `
-            setapikey "${{ secrets.GH_VCPKG_PACKAGES }}" `
-            -Source "${{ env.FEED_URL }}"
+          echo "VCPKG_DIR=${{ runner.temp }}/vcpkg" >> $env:GITHUB_ENV
+          echo "VCPKG_ROOT=${{ runner.temp }}/vcpkg" >> $env:GITHUB_ENV
+          echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $env:GITHUB_ENV
 
-      - name: Add NuGet sources
-        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
-        shell: bash
+      - name: Set up binary cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.temp }}/vcpkg-cache
+          key: vcpkg-cache-${{ runner.os }}-${{ matrix.os }}-${{ matrix.build-cversion }}-${{ env.VCPKG_COMMIT_SHA }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
+          restore-keys: |
+            vcpkg-cache-${{ runner.os }}-${{ matrix.os }}-${{ matrix.build-cversion }}-${{ env.VCPKG_COMMIT_SHA }}
+
+      - name: Clone and checkout vcpkg
         run: |
-          mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
-            sources add \
-            -Source "${{ env.FEED_URL }}" \
-            -StorePasswordInClearText \
-            -Name GitHubPackages \
-            -UserName "${{ env.USERNAME }}" \
-            -Password "${{ secrets.GH_VCPKG_PACKAGES }}"
-          mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
-            setapikey "${{ secrets.GH_VCPKG_PACKAGES }}" \
-            -Source "${{ env.FEED_URL }}"
+          git clone https://github.com/microsoft/vcpkg.git --branch master ${{ env.VCPKG_DIR }}
+          git -C ${{ env.VCPKG_DIR }} checkout ${{ env.VCPKG_COMMIT_SHA }}
 
-      # Install vcpkg dependencies
-      - name: Install vcpkg dependencies 
-        if: startsWith(matrix.os, 'windows')
+      - name: Bootstrap vcpkg (Unix)
+        if: "!startsWith(runner.os, 'Windows')"
+        run: ${{ env.VCPKG_DIR }}/bootstrap-vcpkg.sh -disableMetrics
+
+      - name: Bootstrap vcpkg (Windows)
+        if: startsWith(runner.os, 'Windows')
         shell: pwsh
-        run:  |
-          cd ${{ github.workspace }}
-          ${{ env.VCPKG_EXE }} install --triplet x64-windows
-
-      - name: Install vcpkg dependencies 
-        if: startsWith(matrix.os, 'ubuntu')
-        shell: bash
-        run:  |
-          cd ${{ github.workspace }}
-          ${{ env.VCPKG_EXE }} install --triplet x64-linux-dynamic
-
-      - name: Install vcpkg dependencies 
-        if: startsWith(matrix.os, 'macos')
-        shell: bash
-        run:  |
-          cd ${{ github.workspace }}
-          ${{ env.VCPKG_EXE }} install --triplet x64-osx-dynamic
+        run: ${{ env.VCPKG_DIR }}/bootstrap-vcpkg.bat -disableMetrics
 
       # Build the package
       - name: Windows build


### PR DESCRIPTION
Updated vcpkg setup and environment variables in GitHub Actions workflow to use `actions/cache` instead of nuget to cache vcpkg dependencies. This is a simpler setup since we do not need to package and release the vcpkg binary artifacts, which seems to be the main advantage of using nuget.

The new setup follow the one in https://github.com/biovault/HDILib

Drive-by:
- Update several actions used on the CI