### PR TITLE
Use `mv_project_defaults()` for setting CMake defaults

### DIFF
--- a/ExampleAnalysis/CMakeLists.txt
+++ b/ExampleAnalysis/CMakeLists.txt
@@ -12,14 +12,6 @@ PROJECT("ExampleAnalysisPlugin" LANGUAGES CXX)
 # -----------------------------------------------------------------------------
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MD")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
-endif()
 
 # -----------------------------------------------------------------------------
 # Dependencies
@@ -27,6 +19,7 @@ endif()
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 
 find_package(ManiVault COMPONENTS Core PointData CONFIG QUIET)
+mv_project_defaults()
 
 # -----------------------------------------------------------------------------
 # Include Common directory
@@ -67,10 +60,10 @@ target_include_directories(${PROJECT_NAME} PRIVATE Common)
 # Request C++20
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 
-# Enable unity build
-if(MV_UNITY_BUILD)
-    set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES 
+    AUTOMOC ON
+    UNITY_BUILD ${MV_UNITY_BUILD}
+)
 
 # -----------------------------------------------------------------------------
 # Target library linking

--- a/ExampleData/CMakeLists.txt
+++ b/ExampleData/CMakeLists.txt
@@ -12,14 +12,6 @@ PROJECT("ExampleDataPlugin" LANGUAGES CXX)
 # -----------------------------------------------------------------------------
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MD")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
-endif()
 
 # Include cmake tools
 include(GenerateExportHeader)
@@ -30,6 +22,7 @@ include(GenerateExportHeader)
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 
 find_package(ManiVault COMPONENTS Core PointData CONFIG QUIET)
+mv_project_defaults()
 
 # -----------------------------------------------------------------------------
 # Include Common directory
@@ -81,12 +74,11 @@ target_include_directories(${PROJECT_NAME} PRIVATE "${ManiVault_INCLUDE_DIR}")
 # Request C++20
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 
-set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${PLUGIN_HEADERS}")
-
-# Enable unity build
-if(MV_UNITY_BUILD)
-    set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES 
+    AUTOMOC ON
+    UNITY_BUILD ${MV_UNITY_BUILD}
+    PUBLIC_HEADER "${PLUGIN_HEADERS}"
+)
 
 # -----------------------------------------------------------------------------
 # Target library linking

--- a/ExampleDependencies/CMakeLists.txt
+++ b/ExampleDependencies/CMakeLists.txt
@@ -13,7 +13,7 @@ PROJECT("ExampleDependenciesPlugin" LANGUAGES CXX C)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-include(get_cpm.cmake)
+include(cmake/get_cpm.cmake)
 
 # -----------------------------------------------------------------------------
 # Dependencies

--- a/ExampleDependencies/CMakeLists.txt
+++ b/ExampleDependencies/CMakeLists.txt
@@ -12,16 +12,8 @@ PROJECT("ExampleDependenciesPlugin" LANGUAGES CXX C)
 # -----------------------------------------------------------------------------
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MD")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
-endif()
-
-include(cmake/get_cpm.cmake)
+include(get_cpm.cmake)
 
 # -----------------------------------------------------------------------------
 # Dependencies
@@ -29,6 +21,7 @@ include(cmake/get_cpm.cmake)
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 
 find_package(ManiVault COMPONENTS Core PointData CONFIG QUIET)
+mv_project_defaults()
 
 CPMAddPackage(
   NAME highway
@@ -93,10 +86,10 @@ target_include_directories(${PROJECT_NAME} PRIVATE "${ManiVault_INCLUDE_DIR}")
 # Request C++20
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 
-# Enable unity build
-if(MV_UNITY_BUILD)
-    set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES 
+    AUTOMOC ON
+    UNITY_BUILD ${MV_UNITY_BUILD}
+)
 
 # -----------------------------------------------------------------------------
 # Target library linking

--- a/ExampleLoader/CMakeLists.txt
+++ b/ExampleLoader/CMakeLists.txt
@@ -12,14 +12,6 @@ PROJECT("ExampleLoaderPlugin" LANGUAGES CXX)
 # -----------------------------------------------------------------------------
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MD")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
-endif()
 
 # -----------------------------------------------------------------------------
 # Dependencies
@@ -27,6 +19,7 @@ endif()
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 
 find_package(ManiVault COMPONENTS Core PointData CONFIG QUIET)
+mv_project_defaults()
 
 # -----------------------------------------------------------------------------
 # Include Common directory
@@ -64,10 +57,10 @@ target_include_directories(${PROJECT_NAME} PRIVATE "${ManiVault_INCLUDE_DIR}")
 # Request C++20
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 
-# Enable unity build
-if(MV_UNITY_BUILD)
-    set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES 
+    AUTOMOC ON
+    UNITY_BUILD ${MV_UNITY_BUILD}
+)
 
 # -----------------------------------------------------------------------------
 # Target library linking

--- a/ExampleTransformation/CMakeLists.txt
+++ b/ExampleTransformation/CMakeLists.txt
@@ -12,14 +12,6 @@ PROJECT("ExampleTransformationPlugin" LANGUAGES CXX)
 # -----------------------------------------------------------------------------
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MD")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
-endif()
 
 # -----------------------------------------------------------------------------
 # Dependencies
@@ -27,6 +19,7 @@ endif()
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 
 find_package(ManiVault COMPONENTS Core PointData CONFIG QUIET)
+mv_project_defaults()
 
 # -----------------------------------------------------------------------------
 # Include Common directory
@@ -64,10 +57,10 @@ target_include_directories(${PROJECT_NAME} PRIVATE "${ManiVault_INCLUDE_DIR}")
 # Request C++20
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 
-# Enable unity build
-if(MV_UNITY_BUILD)
-    set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES 
+    AUTOMOC ON
+    UNITY_BUILD ${MV_UNITY_BUILD}
+)
 
 # -----------------------------------------------------------------------------
 # Target library linking

--- a/ExampleView/CMakeLists.txt
+++ b/ExampleView/CMakeLists.txt
@@ -12,14 +12,6 @@ PROJECT("ExampleViewPlugin" LANGUAGES CXX)
 # -----------------------------------------------------------------------------
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MD")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
-endif()
 
 # -----------------------------------------------------------------------------
 # Dependencies
@@ -27,6 +19,7 @@ endif()
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 
 find_package(ManiVault COMPONENTS Core PointData CONFIG QUIET)
+mv_project_defaults()
 
 # -----------------------------------------------------------------------------
 # Include Common directory
@@ -68,10 +61,10 @@ target_include_directories(${PROJECT_NAME} PRIVATE "${ManiVault_INCLUDE_DIR}")
 # Request C++20
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 
-# Enable unity build
-if(MV_UNITY_BUILD)
-    set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES 
+    AUTOMOC ON
+    UNITY_BUILD ${MV_UNITY_BUILD}
+)
 
 # -----------------------------------------------------------------------------
 # Target library linking

--- a/ExampleViewJS/CMakeLists.txt
+++ b/ExampleViewJS/CMakeLists.txt
@@ -12,14 +12,6 @@ PROJECT("ExampleViewJSPlugin" LANGUAGES CXX)
 # -----------------------------------------------------------------------------
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MD")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
-endif()
 
 # -----------------------------------------------------------------------------
 # Dependencies
@@ -27,6 +19,7 @@ endif()
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 
 find_package(ManiVault COMPONENTS Core PointData CONFIG QUIET)
+mv_project_defaults()
 
 # -----------------------------------------------------------------------------
 # Include Common directory
@@ -83,10 +76,10 @@ target_include_directories(${PROJECT_NAME} PRIVATE "${ManiVault_INCLUDE_DIR}")
 # Request C++20
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 
-# Enable unity build
-if(MV_UNITY_BUILD)
-    set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES 
+    AUTOMOC ON
+    UNITY_BUILD ${MV_UNITY_BUILD}
+)
 
 # -----------------------------------------------------------------------------
 # Target library linking

--- a/ExampleViewOpenGL/CMakeLists.txt
+++ b/ExampleViewOpenGL/CMakeLists.txt
@@ -12,14 +12,6 @@ PROJECT("ExampleViewOpenGLPlugin" LANGUAGES CXX)
 # -----------------------------------------------------------------------------
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MD")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
-endif()
 
 # -----------------------------------------------------------------------------
 # Dependencies
@@ -27,6 +19,7 @@ endif()
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets OpenGL OpenGLWidgets REQUIRED)
 
 find_package(ManiVault COMPONENTS Core PointData CONFIG QUIET)
+mv_project_defaults()
 
 # -----------------------------------------------------------------------------
 # Include Common directory
@@ -78,10 +71,10 @@ target_include_directories(${PROJECT_NAME} PRIVATE "${ManiVault_INCLUDE_DIR}")
 # Request C++20
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 
-# Enable unity build
-if(MV_UNITY_BUILD)
-    set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES 
+    AUTOMOC ON
+    UNITY_BUILD ${MV_UNITY_BUILD}
+)
 
 # -----------------------------------------------------------------------------
 # Target library linking

--- a/ExampleWriter/CMakeLists.txt
+++ b/ExampleWriter/CMakeLists.txt
@@ -12,14 +12,6 @@ PROJECT("ExampleWriterPlugin" LANGUAGES CXX)
 # -----------------------------------------------------------------------------
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MD")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
-endif()
 
 # -----------------------------------------------------------------------------
 # Dependencies
@@ -27,6 +19,7 @@ endif()
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 
 find_package(ManiVault COMPONENTS Core PointData CONFIG QUIET)
+mv_project_defaults()
 
 # -----------------------------------------------------------------------------
 # Include Common directory
@@ -64,10 +57,10 @@ target_include_directories(${PROJECT_NAME} PRIVATE "${ManiVault_INCLUDE_DIR}")
 # Request C++20
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 
-# Enable unity build
-if(MV_UNITY_BUILD)
-    set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES 
+    AUTOMOC ON
+    UNITY_BUILD ${MV_UNITY_BUILD}
+)
 
 # -----------------------------------------------------------------------------
 # Target library linking


### PR DESCRIPTION
Use `mv_project_defaults()` as introduced in https://github.com/ManiVaultStudio/core/pull/1240.

Drive-by:
- Remove unused `CMAKE_AUTORCC` and `CMAKE_MODULE_PATH`
- Simplify unity build setup
- Prefer target based `AUTOMOC` property

Analogous to https://github.com/ManiVaultStudio/Scatterplot/pull/241